### PR TITLE
Sleep for IAM propagation

### DIFF
--- a/.github/workflows/deployment_tests.yml
+++ b/.github/workflows/deployment_tests.yml
@@ -83,8 +83,7 @@ jobs:
       - name: Build App
         run: |
           cd GCP/app/build/helloworld
-          sleep 300
-          gcloud artifacts repositories create app-repo --repository-format=docker --location=europe-west2 --description="Repository for storing app"
+          timeout 420 bash -c 'while ! gcloud artifacts repositories create app-repo --repository-format=docker --location=europe-west2 --description="Repository for storing app"; do echo "Retrying in 30s" && sleep 30; done'
           gcloud builds submit --tag europe-west2-docker.pkg.dev/${{ steps.vars.outputs.GCP_PROJECT_ID }}/app-repo/helloworld
 
       # Configure yaml files to contain relevant project info

--- a/.github/workflows/deployment_tests.yml
+++ b/.github/workflows/deployment_tests.yml
@@ -83,6 +83,7 @@ jobs:
       - name: Build App
         run: |
           cd GCP/app/build/helloworld
+          sleep 300
           gcloud artifacts repositories create app-repo --repository-format=docker --location=europe-west2 --description="Repository for storing app"
           gcloud builds submit --tag europe-west2-docker.pkg.dev/${{ steps.vars.outputs.GCP_PROJECT_ID }}/app-repo/helloworld
 


### PR DESCRIPTION
In deployment tests, Cloud Run and App Engine tests were originally after Kubernetes tests to give time for the IAM permissions for the service account to propagate.  
Have added 5 minute sleep before creating the artifact registry repository, to avoid the permissions error