### PR TITLE
Develop

### DIFF
--- a/.github/workflows/deployment_tests.yml
+++ b/.github/workflows/deployment_tests.yml
@@ -79,27 +79,6 @@ jobs:
           sed -i "s/<image_uri>/europe-west2-docker.pkg.dev\/${{ steps.vars.outputs.GCP_PROJECT_ID }}\/app-repo\/helloworld:latest/" gcp_ae.yml
           sed -i "s/<project_id>/${{ steps.vars.outputs.GCP_PROJECT_ID }}/" gcp_cloudrun.yml
 
-
-      # Install kubectl and create gke cluster
-      - name: setup kubectl
-        run: |
-          gcloud components install kubectl
-          gcloud container clusters create-auto mcpdeploytest-cluster --region=europe-west2
-          gcloud container clusters get-credentials mcpdeploytest-cluster --region=europe-west2
-
-      # Setup main.tf, deploy and destroy k8s
-      - name: deploy k8s
-        run: |
-          cd k8s/terraform
-          sed -i "s/gcs-bucket-name/${{ steps.vars.outputs.GCP_PROJECT_ID }}_bucket/" main.tf
-          sed -i "s/source-path/..\/..\/..\/..\/..\//" main.tf
-          cat main.tf
-          terraform init
-          terraform plan -out="./plan.tfplan"
-          terraform apply plan.tfplan
-          terraform plan -destroy -out="./destroy.tfplan"
-          terraform apply destroy.tfplan
-
       # Deploy app image to Artifact Repository
       - name: Build App
         run: |
@@ -127,8 +106,28 @@ jobs:
           terraform apply plan.tfplan
           terraform plan -destroy -out="./destroy.tfplan"
 
+      # Install kubectl and create gke cluster
+      - name: setup kubectl
+        run: |
+          gcloud components install kubectl
+          gcloud container clusters create-auto mcpdeploytest-cluster --region=europe-west2
+          gcloud container clusters get-credentials mcpdeploytest-cluster --region=europe-west2
+
+      # Setup main.tf, deploy and destroy k8s
+      - name: deploy k8s
+        run: |
+          cd k8s/terraform
+          sed -i "s/gcs-bucket-name/${{ steps.vars.outputs.GCP_PROJECT_ID }}_bucket/" main.tf
+          sed -i "s/source-path/..\/..\/..\/..\/..\//" main.tf
+          cat main.tf
+          terraform init
+          terraform plan -out="./plan.tfplan"
+          terraform apply plan.tfplan
+          terraform plan -destroy -out="./destroy.tfplan"
+          terraform apply destroy.tfplan
+
       - name: delete project
-        if : ${{ always() }}
+        if: ${{ always() }}
         run: |
           gcloud projects delete ${{ steps.vars.outputs.GCP_PROJECT_ID }}
-#          gcloud beta billing projects unlink ${{ steps.vars.outputs.GCP_PROJECT_ID }} #Unlinking billing doesn't seem to be necessary
+      #          gcloud beta billing projects unlink ${{ steps.vars.outputs.GCP_PROJECT_ID }} #Unlinking billing doesn't seem to be necessary

--- a/.github/workflows/deployment_tests.yml
+++ b/.github/workflows/deployment_tests.yml
@@ -83,7 +83,7 @@ jobs:
       - name: Build App
         run: |
           cd GCP/app/build/helloworld
-          gcloud artifacts repositories create app-repo --repository-format=docker --location=europe-west2 --description="Repository for storing app"
+          timeout 420 bash -c 'while ! gcloud artifacts repositories create app-repo --repository-format=docker --location=europe-west2 --description="Repository for storing app"; do echo "Retrying in 30s" && sleep 30; done'
           gcloud builds submit --tag europe-west2-docker.pkg.dev/${{ steps.vars.outputs.GCP_PROJECT_ID }}/app-repo/helloworld
 
       # Configure yaml files to contain relevant project info

--- a/cloudrun_locals.tf
+++ b/cloudrun_locals.tf
@@ -5,8 +5,6 @@ locals {
       annotations = {
         "run.googleapis.com/client-name"    = "terraform"
         "run.googleapis.com/ingress"        = "all"
-        "run.googleapis.com/ingress-status" = "all"
-
       }
     }
     template_metadata = {
@@ -31,6 +29,10 @@ locals {
     for key, specs in local.cloudrun_components_specs:
       key => merge(lookup(local.cloudrun_components, "common", {}), specs)
   }
+
+  cloudrun_autogenerate_revision_name = {for service, spec in local.cloudrun_specs: service =>
+    try(lookup(spec.template["metadata"], "name", null), null) == null ? lookup(spec, "autogenerate_revision_name", true) : false}
+
   cloudrun_iam = {
     for key, specs in local.cloudrun_specs:
       key => lookup(local.cloudrun_specs[key], "iam", {})

--- a/docs/GCP_CLOUDRUN.md
+++ b/docs/GCP_CLOUDRUN.md
@@ -1,7 +1,10 @@
 # Google Cloud Run 
 Cloud Run manages the deployment of scalable containerized serverless applications [(Documentation)](https://cloud.google.com/run)
 ## Prerequisites
-* There must be an existing Google Cloud Project, with `cloudresourcemanager.googleapis.com` enabled
+* There must be an existing Google Cloud Project, with the following API's enabled:
+  * `cloudresourcemanager.googleapis.com` 
+  * `run.googleapis.com`
+  * `iam.googleapis.com`
 * There should be an existing image in Google Artifact Registry (or Container Registry) that the Cloud Run service will use
 * The user performing the deployment must have permissions to:
   * Deploy cloudrun services. Can use `roles/run.admin` or a custom role containing:
@@ -13,7 +16,7 @@ Cloud Run manages the deployment of scalable containerized serverless applicatio
     or
     * `roles/storage.objectViewer` on the Container Registry Bucket
   * Enable services
-    * `roles/servicemanagement.serviceConsumer`
+    * `roles/serviceUsage.serviceUsageAdmin`
   * Permission to act as the Runtime Service Account
     * `iam.serviceAccounts.actAs`
   * Update IAM policy
@@ -30,6 +33,7 @@ Cloud Run manages the deployment of scalable containerized serverless applicatio
 | `image`                       | string |                                       true                                        | URI of where the image to be hosted is contained                                                                                                                                                                                                |                            none                             |
 | `service_account_name`        | string |                                       false                                       | Service Account to be used as Cloud Run runtime service account, defaults to the Compute Engine default service account                                                                                                                         |                            none                             |
 | `auth`                        |  bool  |                                       true                                        | Whether authentication is required to access service                                                                                                                                                                                            |                            false                            |
+| `autogenerate_revision_name`  |  bool  |                                       false                                       | Whether to autogenerate the revision name, default is `true`, to specify revision name `templates.metadata.name` should be set                                                                                                                  |  true if `template.metadata.name` not set, false if is set  |
 | `environment_vars`            |  map   |                                       false                                       | Any environment variables to include as for image. Key is the name of the variable and value is the string it represents                                                                                                                        |                            none                             |
 | `iam`                         |  map   |                               true if `auth = true`                               | If authentication is required to access the service, include the iam block                                                                                                                                                                      |                            false                            |
 | `iam.binding`                 |  map   | true if `replace_policy = true`, otherwise include if you want to update bindings | A block of roles and the members who will be assigned the roles. Keys should be the role, and the value for each key is the list of members assigned that role                                                                                  |                            none                             |
@@ -41,7 +45,7 @@ Cloud Run manages the deployment of scalable containerized serverless applicatio
 | `traffic`                     |  list  |                                       false                                       | list of traffic allocation configs across revisions                                                                                                                                                                                             |               100% traffic to latest revision               |
 | `traffic.-.percent`           |  map   |                            true if `traffic.-` exists                             | The percentage of traffic for revision, if `revision_name` is not specified latest revision is used                                                                                                                                             |                            none                             |
 | `traffic.-.revision_name`     | string |                                       false                                       | The name of the revision the traffic should be allocated to                                                                                                                                                                                     | 'latest_revision' is set to true if this key is not present |
-| `secrets`                     |  map   |                                       false                                       | Map of secrets and their mount location, see [below](#Secrets)for attributes                                                                                                                                                                    |                                                             |
+| `secrets`                     |  map   |                                       false                                       | Map of secrets and their mount location, see [below](#Secrets)for attributes                                                                                                                                                                    |                            none                             |
 
 ### IAM Settings
 The IAM policy for the cloudrun service can be configured using the settings described below. 

--- a/tests/mcp/unit_tests/cloudrun/main.tf
+++ b/tests/mcp/unit_tests/cloudrun/main.tf
@@ -46,3 +46,15 @@ data external test_domain {
 output test_domain {
   value = data.external.test_domain.result
 }
+
+data external test_autogenerate_revision_name {
+  query = {
+    for service, value in local.cloudrun_autogenerate_revision_name:
+      service => tostring(value)
+  }
+  program = ["python", "${path.module}/test_cloudrun_autogenerate_revision_name.py"]
+}
+
+output test_autogenerate_revision_name {
+  value = data.external.test_autogenerate_revision_name.result
+}

--- a/tests/mcp/unit_tests/cloudrun/resources/gcp_cloudrun.yml
+++ b/tests/mcp/unit_tests/cloudrun/resources/gcp_cloudrun.yml
@@ -6,10 +6,12 @@ components:
     app1:
       name: "app1"
       domain: "app1.company.com"
+      autogenerate_revision_name: true
       template:
         containers:
           image: gcr.io/google-containers/nginx
         metadata:
+          name: "app1-revision-name"
           annotations:
             "run.googleapis.com/client-name": "terraform"
       auth: true
@@ -49,4 +51,5 @@ components:
       auth: false
     app2:
       name: "app2"
+      autogenerate_revision_name: false
       domain: "app2.company.com"

--- a/tests/mcp/unit_tests/cloudrun/test_cloudrun_autogenerate_revision_name.py
+++ b/tests/mcp/unit_tests/cloudrun/test_cloudrun_autogenerate_revision_name.py
@@ -1,0 +1,28 @@
+from sys import path, stderr
+
+try:
+    path.insert(1, '../../../test_fixtures/python_validator')
+    from python_validator import python_validator
+except Exception as e:
+    print(e, stderr)
+
+"""
+    Tests that autogenerate_revision_name is set as follows:
+        - autogenerate_revision_name=true if there is nothing specified in template.metadata.name
+        - autogenerate_revision_name=false if autogenerate_revision_name attribute is set to false in gcp_cloudrun.yml
+        - autogenerate_revision_name=false if template.metadata.name is specified, 
+          regardless of what autogenerate_revision_name is set to in gcp_cloudrun.yml
+    set to false if a revision name is specified in template.metadata.name 
+
+"""
+
+expected_data = {
+    'app1-service': 'true',
+    'app2': 'false',
+    'app1': 'false'
+
+
+}
+
+if __name__ == '__main__':
+    python_validator(expected_data)

--- a/tests/mcp/unit_tests/cloudrun/test_cloudrun_domain.py
+++ b/tests/mcp/unit_tests/cloudrun/test_cloudrun_domain.py
@@ -7,13 +7,7 @@ except Exception as e:
     print(e, stderr)
 
 """
-    Tests that secrets are added to correct variable for the environment attachment type/
-    Config structure should look like
-    secrets:
-      secret_1: 
-        version: $Version
-        env_name: $Environent-variable-name 
-        
+    Tests if domains are read from the configuration
 
 """
 


### PR DESCRIPTION
### Bug Fix
Encountered an issue when attempting to update a cloud run service using this module. The update failed as it attempted to replace an existing revision (`google.cloud.run.v1.Services.ReplaceService`). The error received in Google Cloud Logging was `Revision named '[service]-[previous-revision-name]' with different configuration already exists.`

It is possible that in this case `templates.metadata.name` was present during import, so terraform set `autogenerate_revision_name` to false (see [documentaion](autogenerate_revision_name)).   
Added the missing `autogenerate_revision_name` key to the module, which is set to:
  - `true` if there is nothing specified in `template.metadata.name`
  - `false` if `autogenerate_revision_name` attribute is set to false in `gcp_cloudrun.yml`
  - `false` if `template.metadata.name` is specified, regardless of what `autogenerate_revision_name` is set to in `gcp_cloudrun.yml` 

### Changes
* Removed `google_project_service` service, therefore requiring `iam.googleapis.com` and `run.googleapis.com` APIs to be enabled before deployment.
* Removed the default annotation `"run.googleapis.com/ingress-status" = "all"` as that is an output only annotation that does not need to be set in module.
* Updated documentation and unit tests to reflect changes