### PR TITLE
Use workload identity federation

### DIFF
--- a/.github/workflows/deployment_tests.yml
+++ b/.github/workflows/deployment_tests.yml
@@ -32,12 +32,17 @@ jobs:
         with:
           terraform_wrapper: false
 
-      # Install gcloud sdk and set the service account
-      - name: Setup Cloud SDK
-        uses: google-github-actions/setup-gcloud@v0
+      # Authenticate using workload identity federation
+      - id: 'auth'
+        uses: 'google-github-actions/auth@v1'
         with:
-          service_account_key: ${{secrets.GCP_SA_KEY}}
-          export_default_credentials: true
+          service_account: ${{secrets.GCP_SA_EMAIL}}
+          workload_identity_provider: ${{secrets.GCP_WORKLOAD_IDENTITY_PROVIDER}}
+          token_format: 'access_token'
+          access_token_lifetime: 1200s # 20 minutes
+
+      - name: 'Set up Cloud SDK'
+        uses: 'google-github-actions/setup-gcloud@v1'
 
       - name: Set constant variables
         id: vars

--- a/.github/workflows/deployment_tests.yml
+++ b/.github/workflows/deployment_tests.yml
@@ -6,6 +6,11 @@ on:
       - main
       - develop
 
+permissions:
+  contents: 'read'
+  id-token: 'write'
+
+
 jobs:
   ############################# Deployment Tests for MCP modules #####################################################
   MCP-tests:

--- a/docs/GCP_APP_ENGINE.md
+++ b/docs/GCP_APP_ENGINE.md
@@ -171,7 +171,7 @@ location_id: "europe-west2"
 components:
   common:
     entrypoint: python main.py
-    runtime: python38
+    runtime: python311
     env: flex
     env_variables:
       GCP_PROJECT_ID: *project_id

--- a/providers.tf
+++ b/providers.tf
@@ -14,7 +14,3 @@ terraform {
     }
   }
 }
-
-provider "google" {}
-provider "google-beta" {}
-provider "kubernetes" {}

--- a/tests/mcp/deployment/GCP/gcp_ae.yml
+++ b/tests/mcp/deployment/GCP/gcp_ae.yml
@@ -5,7 +5,7 @@ flex_delay: "2m"
 components:
   common:
     entrypoint: python main.py
-    runtime: python38
+    runtime: python311
     env: flex
   specs:
     default:


### PR DESCRIPTION
* Use workload identity federation for deployment tests
* Update app engine runtime to try and resolve previous failure
* Remove unnecessary provider blocks to prevent warning on apply