### PR TITLE
Update App Engine deployment tests

### DIFF
--- a/docs/GCP_APP_ENGINE.md
+++ b/docs/GCP_APP_ENGINE.md
@@ -106,7 +106,7 @@ The key `bucket_name` is the name of the bucket which holds the services files.
 | `components.spec.<app>.migrate_traffic` | bool | false | will migrate all traffic to a new version of the deployed app | false |
 
 Example:
-```yamlex
+```yaml
 create_google_project: true
 project_id: &project_id <google project id>
 bucket_name: <cloud storage bucket name>
@@ -146,13 +146,12 @@ components:
 Below is a list of attributes which are available to both GAE standard and GAE flexible apps (this
  is not the same as components.common which is just a place to define defaults for all apps/services)
 
-| Key                   |  Type  | Required | Description                                                                                                                                                                                                                                                                                                                                                              |                     Default                      |
-|:----------------------|:------:|:--------:|:-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:------------------------------------------------:|
-| `env`                 | string |  false   | either `flex` or `standard` are the only values allowed here                                                                                                                                                                                                                                                                                                             |                    `standard`                    |
-| `root_dir`            | string |  false   | on-disk directory for the app/service. The value is relative to the project root where the `gcp_ae.yml` and `project.yml` files are located. If this is omitted, MCCF will expect files to be in a directory of the same name as the app. So, for the default app, you will either need a directory called `default` or set this value to the real name of the directory | spec key name (I.e. the name of the app/service) |
-| `runtime`             | string |   true   | Desired runtime, e.g. "python", "nodejs", "java"                                                                                                                                                                                                                                                                                                                         |                       none                       |
-| `runtime_api_version` | string |  false   | The version of the API in the given runtime environment (used by flexible environment)                                                                                                                                                                                                                                                                                   |                       none                       |
-| `entrypoint`          | string |   true   | command to run to start the app/service when deployed to GAE                                                                                                                                                                                                                                                                                                             |                       none                       |
+| Key          |  Type  | Required | Description                                                                                                                                                                                                                                                                                                                                                              |                     Default                      |
+|:-------------|:------:|:--------:|:-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:------------------------------------------------:|
+| `env`        | string |  false   | either `flex` or `standard` are the only values allowed here                                                                                                                                                                                                                                                                                                             |                    `standard`                    |
+| `root_dir`   | string |  false   | on-disk directory for the app/service. The value is relative to the project root where the `gcp_ae.yml` and `project.yml` files are located. If this is omitted, MCCF will expect files to be in a directory of the same name as the app. So, for the default app, you will either need a directory called `default` or set this value to the real name of the directory | spec key name (I.e. the name of the app/service) |
+| `runtime`    | string |   true   | Desired runtime. <br>- Standard environment uses format like: `python11`, `java17` <br>- Flexible environment uses format like `python`, `java` with the version set using `runtime_api_version` attribute                                                                                                                                                               |                       none                       |
+| `entrypoint` | string |   true   | command to run to start the app/service when deployed to GAE                                                                                                                                                                                                                                                                                                             |                       none                       |
 
 #### Google App Engine Standard component configuration  
 attributes specific to only GAE standard  
@@ -164,6 +163,9 @@ attributes specific to only GAE standard
 | `upload_path_regex` | string | true within static_files context only |             |  none   |
 
 #### Google App Engine Flexible component Configuration  
+The runtime for the flexible app configuration cannot take the form like "python311", 
+but instead would need to use the runtime `"python"` and set `runtime_api_version` to "3.11" 
+
 An example flexible app engine configuration:  
 ```yaml
 project_id: &project_id ae-flex-test
@@ -172,7 +174,8 @@ location_id: "europe-west2"
 components:
   common:
     entrypoint: python main.py
-    runtime: python311
+    runtime: python
+    runtime_api_version: 3.11
     env: flex
     env_variables:
       GCP_PROJECT_ID: *project_id

--- a/docs/GCP_APP_ENGINE.md
+++ b/docs/GCP_APP_ENGINE.md
@@ -175,7 +175,7 @@ components:
   common:
     entrypoint: python main.py
     runtime: python
-    runtime_api_version: 3.11
+    runtime_api_version: "3.11"
     env: flex
     env_variables:
       GCP_PROJECT_ID: *project_id

--- a/docs/GCP_APP_ENGINE.md
+++ b/docs/GCP_APP_ENGINE.md
@@ -146,21 +146,22 @@ components:
 Below is a list of attributes which are available to both GAE standard and GAE flexible apps (this
  is not the same as components.common which is just a place to define defaults for all apps/services)
 
-| Key | Type | Required | Description | Default |
-|:----|:----:|:--------:|:------------|:-------:|
-| `env` | string | false | either `flex` or `standard` are the only values allowed here | `standard` |
-| `root_dir` | string | false | on-disk directory for the app/service. The value is relative to the project root where the `gcp_ae.yml` and `project.yml` files are located. If this is omitted, MCCF will expect files to be in a directory of the same name as the app. So, for the default app, you will either need a directory called `default` or set this value to the real name of the directory | spec key name (I.e. the name of the app/service) |
-| `runtime` | string | true | GAE available runtime. This differs between environment. Check the GAE docs for details | none |
-| `entrypoint` | string | true | command to run to start the app/service when deployed to GAE | none |
+| Key                   |  Type  | Required | Description                                                                                                                                                                                                                                                                                                                                                              |                     Default                      |
+|:----------------------|:------:|:--------:|:-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:------------------------------------------------:|
+| `env`                 | string |  false   | either `flex` or `standard` are the only values allowed here                                                                                                                                                                                                                                                                                                             |                    `standard`                    |
+| `root_dir`            | string |  false   | on-disk directory for the app/service. The value is relative to the project root where the `gcp_ae.yml` and `project.yml` files are located. If this is omitted, MCCF will expect files to be in a directory of the same name as the app. So, for the default app, you will either need a directory called `default` or set this value to the real name of the directory | spec key name (I.e. the name of the app/service) |
+| `runtime`             | string |   true   | Desired runtime, e.g. "python", "nodejs", "java"                                                                                                                                                                                                                                                                                                                         |                       none                       |
+| `runtime_api_version` | string |  false   | The version of the API in the given runtime environment (used by flexible environment)                                                                                                                                                                                                                                                                                   |                       none                       |
+| `entrypoint`          | string |   true   | command to run to start the app/service when deployed to GAE                                                                                                                                                                                                                                                                                                             |                       none                       |
 
 #### Google App Engine Standard component configuration  
 attributes specific to only GAE standard  
 
-| Key | Type | Required | Description | Default |
-|:----|:----:|:--------:|:------------|:-------:|
-| `static_files` | string | false | | none |
-| `static_files.path` | string | true within static_files context only | | none |
-| `upload_path_regex` | string |  true within static_files context only | | none |
+| Key                 |  Type  |               Required                | Description | Default |
+|:--------------------|:------:|:-------------------------------------:|:------------|:-------:|
+| `static_files`      | string |                 false                 |             |  none   |
+| `static_files.path` | string | true within static_files context only |             |  none   |
+| `upload_path_regex` | string | true within static_files context only |             |  none   |
 
 #### Google App Engine Flexible component Configuration  
 An example flexible app engine configuration:  

--- a/gcp_ae.tf
+++ b/gcp_ae.tf
@@ -113,7 +113,7 @@ resource "google_app_engine_flexible_app_version" "self" {
   runtime_api_version = lookup(each.value, "runtime_api_version", null)
   runtime_channel = lookup(each.value, "runtime_channel", null)
   runtime_main_executable_path = lookup(each.value, "runtime_main_executable_path", null)
-  serving_status = lookup(each.value, "serving_status", null)
+  serving_status = lookup(each.value, "serving_status", "SERVING")
   env_variables = local.env_variables[each.key]
 
   //noinspection HILUnresolvedReference

--- a/tests/mcp/deployment/GCP/gcp_ae.yml
+++ b/tests/mcp/deployment/GCP/gcp_ae.yml
@@ -5,10 +5,12 @@ flex_delay: "2m"
 components:
   common:
     entrypoint: python main.py
-    runtime: python311
+    runtime: python
+    runtime_api_version: "3.10"
     env: flex
   specs:
     default:
+      version_id: v2
       manual_scaling:
         instance: 1
       deployment:

--- a/tests/mcp/deployment/GCP/gcp_ae.yml
+++ b/tests/mcp/deployment/GCP/gcp_ae.yml
@@ -6,11 +6,11 @@ components:
   common:
     entrypoint: python main.py
     runtime: python
-    runtime_api_version: "3.10"
+    runtime_api_version: "3.11"
     env: flex
   specs:
     default:
-      version_id: v2
+      version_id: v1
       manual_scaling:
         instance: 1
       deployment:


### PR DESCRIPTION
The app engine deployment was failing because the runtime was invalid. Format like `python311` is only available for the standard environment, with flexible environment requiring `python` and then setting the `runtime_api_version` to `3.11`. Have updated the documentation to address that. 
Have also updated the `serving_status` attribute to default to `"SERVING"` rather than `null` (possible values are `SERVING` and `STOPPED`)