### PR TITLE
Terraform Google provider version updated

### DIFF
--- a/providers.tf
+++ b/providers.tf
@@ -6,11 +6,11 @@ terraform {
     }
     google = {
       source = "hashicorp/google"
-      version = ">=3.55.0, <5.0.0"
+      version = ">=3.55.0, <6.0.0"
     }
     google-beta = {
       source = "hashicorp/google-beta"
-      version = ">=3.55.0, <5.0.0"
+      version = ">=3.55.0, <6.0.0"
     }
   }
 }


### PR DESCRIPTION
Terraform Google provider version updated to include versions up to v6 to be able to use newer resources